### PR TITLE
Campaigns query/page creation

### DIFF
--- a/packages/gatsby-plugin/src/imports/createPages.js
+++ b/packages/gatsby-plugin/src/imports/createPages.js
@@ -1,152 +1,8 @@
-const articleQuery = `
-  {
-    allWingsArticle {
-      edges {
-        node {
-          article {
-            id
-            title
-            slug
-            content
-            image {
-              url
-            }
-            platforms {
-              all {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              facebook {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              twitter {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-const entryQuery = `
-  {
-    allWingsEntry {
-      edges {
-        node {
-          entry {
-            id
-            title
-            slug
-            content
-            image {
-              url
-            }
-            platforms {
-              all {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              facebook {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              twitter {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-const eventQuery = `
-  {
-    allWingsCampaignEvent {
-      edges {
-        node {
-          id
-          event {
-            id
-            title
-            slug
-            intro
-            description
-            image {
-              url
-            }
-            schedule {
-              start
-            }
-            location {
-              name
-              street
-              city
-              zip
-              country
-            }
-            fee {
-              amount
-              currencyCode
-            }
-            
-            platforms {
-              all {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              facebook {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-              twitter {
-                title
-                description
-                medium {
-                  url
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+import { articleQuery, campaignQuery, entryQuery, eventQuery } from './pagesQueries';
 
 export default async (
   { boundActionCreators: { createPage }, graphql },
-  { templates: { article, event, entry } = {} },
+  { templates: { article, campaign, event, entry } = {} },
 ) => {
   if (!article) {
     console.error('article component unspecified');
@@ -206,5 +62,23 @@ export default async (
         },
       });
     });
+  }
+
+  const campaigns = await graphql(campaignQuery);
+  if (campaigns.data) {
+    campaigns.data.allWingsCampaign.edges.forEach(({ node }) =>
+      // We need to add the ability to change campaign data in Wings (such as the slug here)
+      // if (!node.campaign.slug) return null;
+
+      createPage({
+        // Using id here until slug can be used. See previous comment.
+        path: `/campaigns/${node.campaign.id}`,
+        component: campaign,
+        context: {
+          id: node.campaign.id,
+          campaign: node.campaign,
+        },
+      }),
+    );
   }
 };

--- a/packages/gatsby-plugin/src/imports/pagesQueries/articleQuery.js
+++ b/packages/gatsby-plugin/src/imports/pagesQueries/articleQuery.js
@@ -1,0 +1,42 @@
+export default `
+{
+  allWingsArticle {
+    edges {
+      node {
+        article {
+          id
+          title
+          slug
+          content
+          image {
+            url
+          }
+          platforms {
+            all {
+              title
+              description
+              medium {
+                url
+              }
+            }
+            facebook {
+              title
+              description
+              medium {
+                url
+              }
+            }
+            twitter {
+              title
+              description
+              medium {
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;

--- a/packages/gatsby-plugin/src/imports/pagesQueries/campaignQuery.js
+++ b/packages/gatsby-plugin/src/imports/pagesQueries/campaignQuery.js
@@ -1,0 +1,23 @@
+export default `
+  {
+    allWingsCampaign {
+      edges {
+        node {
+          id
+          campaign {
+            id
+            petitions {
+              id
+              title
+              slug
+              status
+              intro
+              description
+              signatureCount
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/gatsby-plugin/src/imports/pagesQueries/entryQuery.js
+++ b/packages/gatsby-plugin/src/imports/pagesQueries/entryQuery.js
@@ -1,0 +1,42 @@
+export default `
+  {
+    allWingsEntry {
+      edges {
+        node {
+          entry {
+            id
+            title
+            slug
+            content
+            image {
+              url
+            }
+            platforms {
+              all {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+              facebook {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+              twitter {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/gatsby-plugin/src/imports/pagesQueries/eventQuery.js
+++ b/packages/gatsby-plugin/src/imports/pagesQueries/eventQuery.js
@@ -1,0 +1,58 @@
+export default `
+  {
+    allWingsCampaignEvent {
+      edges {
+        node {
+          id
+          event {
+            id
+            title
+            slug
+            intro
+            description
+            image {
+              url
+            }
+            schedule {
+              start
+            }
+            location {
+              name
+              street
+              city
+              zip
+              country
+            }
+            fee {
+              amount
+              currencyCode
+            }
+            platforms {
+              all {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+              facebook {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+              twitter {
+                title
+                description
+                medium {
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/gatsby-plugin/src/imports/pagesQueries/index.js
+++ b/packages/gatsby-plugin/src/imports/pagesQueries/index.js
@@ -1,0 +1,4 @@
+export { default as articleQuery } from './articleQuery';
+export { default as campaignQuery } from './campaignQuery';
+export { default as entryQuery } from './entryQuery';
+export { default as eventQuery } from './eventQuery';

--- a/packages/gatsby-plugin/src/imports/sourceNodes.js
+++ b/packages/gatsby-plugin/src/imports/sourceNodes.js
@@ -1,13 +1,13 @@
-import sourceArticles from './sourceArticles';
-import sourceEntries from './sourceEntries';
-import sourceCampaigns from './sourceCampaigns';
+import { sourceArticles, sourceEntries, sourceEvents, sourceCampaigns } from './sourceQueries';
 
 export default async ({ boundActionCreators: { createNode } }, { endpoint, project, appKey }) => {
   try {
     const articles = await sourceArticles({ endpoint, project, token: appKey });
     articles.forEach(a => createNode(a));
     const campaigns = await sourceCampaigns({ endpoint, project, token: appKey });
-    campaigns.forEach(camp => camp.events.forEach(e => createNode(e)));
+    campaigns.forEach(c => createNode(c));
+    const events = await sourceEvents({ endpoint, project, token: appKey });
+    events.forEach(c => c.events.forEach(e => createNode(e)));
     const entries = await sourceEntries({ endpoint, project, token: appKey });
     entries.forEach(e => createNode(e));
   } catch (e) {

--- a/packages/gatsby-plugin/src/imports/sourceQueries/index.js
+++ b/packages/gatsby-plugin/src/imports/sourceQueries/index.js
@@ -1,0 +1,4 @@
+export { default as sourceArticles } from './sourceArticles';
+export { default as sourceCampaigns } from './sourceCampaigns';
+export { default as sourceEntries } from './sourceEntries';
+export { default as sourceEvents } from './sourceEvents';

--- a/packages/gatsby-plugin/src/imports/sourceQueries/sourceArticles.js
+++ b/packages/gatsby-plugin/src/imports/sourceQueries/sourceArticles.js
@@ -1,4 +1,4 @@
-import { md5, query, ensureNodeFields } from './utils';
+import { md5, query, ensureNodeFields } from '../utils';
 
 const articleToNode = (a) => {
   const node = {

--- a/packages/gatsby-plugin/src/imports/sourceQueries/sourceCampaigns.js
+++ b/packages/gatsby-plugin/src/imports/sourceQueries/sourceCampaigns.js
@@ -1,0 +1,117 @@
+import { md5, query /* , ensureNodeFields */ } from '../utils';
+
+const campaignToNode = (c) => {
+  const node = {
+    campaign: {
+      ...c,
+    },
+    id: c.id,
+    parent: null,
+    children: [],
+    internal: {
+      type: 'WingsCampaign',
+      contentDigest: md5(JSON.stringify(c.id)),
+    },
+  };
+  return node;
+};
+
+const q = `
+  {
+    campaigns {
+      id
+      title
+      slug
+      petitions {
+        id
+        title
+        slug
+        meta {
+          key
+          value
+        }
+        status
+        campaign {
+          id
+        }
+        intro
+        description
+        signatureCount
+        image {
+          id
+          caption
+          alt
+          url
+        }
+      }
+      events {
+        id
+        title
+        slug
+        intro
+        description
+        image {
+          url
+        }
+        schedule {
+          start
+          end
+        }
+        location {
+          name
+          street
+          city
+          zip
+          country
+        } 
+        fee {
+          amount
+          currencyCode
+        }
+        platforms {
+          all {
+            title
+            description
+            medium {
+              url
+            }
+          }
+          facebook {
+            title
+            description
+            medium {
+              url
+            }
+          }
+          twitter {
+            title
+            description
+            medium {
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default async ({ endpoint, project, token }) => {
+  try {
+    const res = await query({
+      query: q,
+      endpoint,
+      token,
+      project,
+    });
+    if (res.error) {
+      console.error('[Wings]: unable to source campaigns', res.error);
+      return [];
+    }
+    console.log(res.data.campaigns);
+    return res.data.campaigns.map(c => campaignToNode(c));
+  } catch (e) {
+    console.log(e);
+    return [];
+  }
+};

--- a/packages/gatsby-plugin/src/imports/sourceQueries/sourceEntries.js
+++ b/packages/gatsby-plugin/src/imports/sourceQueries/sourceEntries.js
@@ -1,4 +1,4 @@
-import { md5, query, ensureNodeFields } from './utils';
+import { md5, query, ensureNodeFields } from '../utils';
 
 const entryToNode = e => ({
   entry: ensureNodeFields(e),

--- a/packages/gatsby-plugin/src/imports/sourceQueries/sourceEvents.js
+++ b/packages/gatsby-plugin/src/imports/sourceQueries/sourceEvents.js
@@ -1,4 +1,4 @@
-import { md5, query, ensureNodeFields } from './utils';
+import { md5, query, ensureNodeFields } from '../utils';
 
 const eventToNode = e => ({
   event: ensureNodeFields({

--- a/packages/gatsby-plugin/src/imports/wingsCampaign.js
+++ b/packages/gatsby-plugin/src/imports/wingsCampaign.js
@@ -1,0 +1,6 @@
+import { compose, mapProps } from 'recompose';
+import withSeo from './withSeo';
+
+const mp = mapProps(({ pathContext: { campaign } = {} }) => ({ campaign }));
+
+export default compose(mp, withSeo('campaign'));


### PR DESCRIPTION
We need to be able to create a page based on a campaign (where we can reference all the petitions available in that campaign).

I've added the source query for this and the page creation.

I refactored the queries and source functions a bit so the structure of the code is neater.

Maarten: it would be good if the campaign data (slug, etc) is editable in Wings.