### PR TITLE
feat: update DataCard

### DIFF
--- a/packages/hummingbird/index.js
+++ b/packages/hummingbird/index.js
@@ -2,6 +2,7 @@
 export { default as Button } from './src/components/Button';
 export { default as Content } from './src/components/Content/Content';
 export { default as LayoutDefault } from './src/components/LayoutDefault';
+export { CustomDataCard as DataCard } from './src/cards/DataCard';
 
 // templates
 export { default as Article } from './src/templates/components/Article';

--- a/packages/hummingbird/src/cards/DataCard.js
+++ b/packages/hummingbird/src/cards/DataCard.js
@@ -1,5 +1,19 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { createCard } from '@wingscms/react';
+
+export const CustomDataCard = (options = []) => {
+  const _options = {};
+  const addOption = (name, Comp) => {
+    _options[name] = <Comp /> || <div />;
+  };
+
+  Object.keys(options).forEach(k => addOption(options[k].name, options[k].comp));
+
+  return ({ data }) => {
+    const Comp = options[data.type] || <div />;
+    return <Comp {...data} />;
+  };
+};
 
 export default createCard({
   name: 'DataCard',


### PR DESCRIPTION
Made it easier to override the DataCard in projects and add custom types.

Usage:

(shadowed `DataCard.js`)

```
import { DataCard } from '@wingscms/hummingbird';

export default createCard({
  name: 'DataCard',
  renderWith: DataCard({
    'exampleType': ({exampleProp}) => <div>{ exampleProp || 'text' }</div>,
  })
});

```

The data in wings would like like:

```
{
  type: 'exampleType',
  exampleProp: 'blah blah blah',
}
```